### PR TITLE
:recycle: refactor: Migrate Redux slices to use use cases

### DIFF
--- a/src/store/slices/authSlice/index.ts
+++ b/src/store/slices/authSlice/index.ts
@@ -1,6 +1,6 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
-import { User } from '../../../types/auth';
-import { firebaseAuthService } from '../../../services/firebaseAuthService';
+import { User } from '../../../domain/entities/User';
+import { authUseCases } from '../../../infrastructure/di/container';
 
 interface AuthState {
   user: User | null;
@@ -21,7 +21,7 @@ const initialState: AuthState = {
 export const login = createAsyncThunk(
   'auth/login',
   async (credentials: { email: string; password: string }) => {
-    const response = await firebaseAuthService.login(credentials);
+    const response = await authUseCases.login(credentials);
     return response;
   }
 );
@@ -29,7 +29,7 @@ export const login = createAsyncThunk(
 export const register = createAsyncThunk(
   'auth/register',
   async (data: { name: string; email: string; password: string; confirmPassword: string }) => {
-    const response = await firebaseAuthService.register(data);
+    const response = await authUseCases.register(data);
     return response;
   }
 );
@@ -37,14 +37,14 @@ export const register = createAsyncThunk(
 export const logout = createAsyncThunk(
   'auth/logout',
   async () => {
-    await firebaseAuthService.logout();
+    await authUseCases.logout();
   }
 );
 
 export const getCurrentUser = createAsyncThunk(
   'auth/getCurrentUser',
   async () => {
-    const response = await firebaseAuthService.getCurrentUser();
+    const response = await authUseCases.getCurrentUser();
     return response;
   }
 );
@@ -52,21 +52,21 @@ export const getCurrentUser = createAsyncThunk(
 export const forgotPassword = createAsyncThunk(
   'auth/forgotPassword',
   async (email: string) => {
-    await firebaseAuthService.forgotPassword(email);
+    await authUseCases.forgotPassword(email);
   }
 );
 
 export const changePassword = createAsyncThunk(
   'auth/changePassword',
   async (data: { currentPassword: string; newPassword: string }) => {
-    await firebaseAuthService.changePassword(data.currentPassword, data.newPassword);
+    await authUseCases.changePassword(data.currentPassword, data.newPassword);
   }
 );
 
 export const updateUserProfile = createAsyncThunk(
   'auth/updateProfile',
   async (data: Partial<User>) => {
-    const response = await firebaseAuthService.updateProfile(data);
+    const response = await authUseCases.updateProfile(data);
     return response;
   }
 );

--- a/src/store/slices/dashboardSlice/index.ts
+++ b/src/store/slices/dashboardSlice/index.ts
@@ -1,6 +1,6 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
-import { DashboardData, ChartData } from '../../../types/dashboard';
-import { firebaseDashboardService } from '../../../services/firebaseDashboardService';
+import { DashboardData, ChartData } from '../../../domain/entities/Dashboard';
+import { dashboardUseCases } from '../../../infrastructure/di/container';
 
 interface DashboardState {
   data: DashboardData | null;
@@ -37,7 +37,7 @@ export const fetchDashboardData = createAsyncThunk(
       throw new Error('Usuário não autenticado');
     }
 
-    const response = await firebaseDashboardService.getDashboardData(userId, period, selectedMonth);
+    const response = await dashboardUseCases.getDashboardData(userId, period, selectedMonth);
     
     
     return response;
@@ -61,7 +61,7 @@ export const fetchChartData = createAsyncThunk(
       throw new Error('Usuário não autenticado');
     }
 
-    const response = await firebaseDashboardService.getChartData(userId, period, selectedMonth);
+    const response = await dashboardUseCases.getChartData(userId, period, selectedMonth);
     
     
     return response;

--- a/src/store/slices/transactionsSlice/index.ts
+++ b/src/store/slices/transactionsSlice/index.ts
@@ -1,6 +1,6 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
-import { Transaction, TransactionFilters, TransactionFormData } from '../../../types/transaction';
-import { firebaseTransactionService } from '../../../services/firebaseTransactionService';
+import { Transaction, TransactionFilters, TransactionFormData } from '../../../domain/entities/Transaction';
+import { transactionUseCases } from '../../../infrastructure/di/container';
 
 interface TransactionsState {
   transactions: Transaction[];
@@ -52,7 +52,7 @@ export const fetchTransactions = createAsyncThunk(
     // Se não é primeira página mas não tem lastDoc, forçar primeira página
     if (!isFirstPage && !lastDoc) {
       
-      const response = await firebaseTransactionService.getTransactions(
+      const response = await transactionUseCases.getTransactions(
         userId,
         state.transactions.filters,
         20,
@@ -67,7 +67,7 @@ export const fetchTransactions = createAsyncThunk(
       };
     }
     
-    const response = await firebaseTransactionService.getTransactions(
+    const response = await transactionUseCases.getTransactions(
       userId,
       state.transactions.filters,
       20,
@@ -101,7 +101,7 @@ export const addTransaction = createAsyncThunk(
     }
 
     
-    const response = await firebaseTransactionService.createTransaction(transaction, userId);
+    const response = await transactionUseCases.createTransaction(transaction, userId);
     
     
     return response;
@@ -111,7 +111,8 @@ export const addTransaction = createAsyncThunk(
 export const updateTransaction = createAsyncThunk(
   'transactions/updateTransaction',
   async (transaction: Transaction) => {
-    const response = await firebaseTransactionService.updateTransaction(transaction.id, transaction);
+    const { id, ...transactionData } = transaction;
+    const response = await transactionUseCases.updateTransaction(id, transactionData);
     return response;
   }
 );
@@ -119,7 +120,7 @@ export const updateTransaction = createAsyncThunk(
 export const deleteTransaction = createAsyncThunk(
   'transactions/deleteTransaction',
   async (id: string) => {
-    await firebaseTransactionService.deleteTransaction(id);
+    await transactionUseCases.deleteTransaction(id);
     return id;
   }
 );
@@ -127,7 +128,7 @@ export const deleteTransaction = createAsyncThunk(
 export const uploadReceipt = createAsyncThunk(
   'transactions/uploadReceipt',
   async ({ file, transactionId }: { file: any; transactionId: string }) => {
-    const response = await firebaseTransactionService.uploadReceipt(file, transactionId);
+    const response = await transactionUseCases.uploadReceipt(file, transactionId);
     return { transactionId, receiptUrl: response };
   }
 );


### PR DESCRIPTION
## Migrate Redux Slices to Use Cases

* Migrate transactionsSlice to use TransactionUseCases
* Migrate authSlice to use AuthUseCases
* Migrate dashboardSlice to use DashboardUseCases
* Replace direct service calls with use cases from DI container
* Use domain entities instead of types folder